### PR TITLE
safe mount letter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,10 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
 
     let disposable = vscode.commands.registerCommand('copy-WSL-path.copy', (e) => {
-        const text = "/mnt" + (e.path as string).replace(':', '');
-        ncp.copy(text);
+        const text = "/mnt" + e.path.replace(':', '');
+        const safeMountLetter = text.match('\/[A-Z]\/')[0];
+        const path = text.replace((safeMountLetter), (safeMountLetter).toLowerCase());
+        ncp.copy(path);
     });
 
     context.subscriptions.push(disposable);


### PR DESCRIPTION
Sometimes windows does not recognizes the case of absolute path's mount letter or disk label. That might ensure the letter comes lower always